### PR TITLE
Merge placeholders of same match type

### DIFF
--- a/autoroutes.pyx
+++ b/autoroutes.pyx
@@ -128,13 +128,14 @@ cdef class Edge:
         cdef:
             list parts
             unsigned int match_type
+            str pattern
         parts = segment.split(':')
         if len(parts) == 2:
             pattern = parts[1]
         else:
             pattern = DEFAULT_MATCH_TYPE
         match_type = MATCH_TYPES.get(pattern, MATCH_REGEX)
-        return pattern, match_type
+        return PATTERNS.get(match_type, pattern), match_type
 
     cdef unsigned int match(self, str path, unsigned int path_len, list params):
         cdef:

--- a/autoroutes.pyx
+++ b/autoroutes.pyx
@@ -109,7 +109,7 @@ cdef class Edge:
     cpdef str compile(self):
         cdef:
             list parts
-            str pattern = DEFAULT_MATCH_TYPE
+            str match_type = DEFAULT_MATCH_TYPE
         self.pattern_start = self.pattern.find('{')  # Slow, but at compile it's ok.
         self.pattern_end = self.pattern.find('}')
         self.pattern_len = len(self.pattern)
@@ -125,9 +125,9 @@ cdef class Edge:
             segment = self.pattern[self.pattern_start:self.pattern_end]
             parts = segment.split(':')
             if len(parts) == 2:
-                pattern = parts[1]
-            self.match_type = MATCH_TYPES.get(pattern, MATCH_REGEX)
-            self.regex = PATTERNS.get(self.match_type, pattern)
+                match_type = parts[1]
+            self.match_type = MATCH_TYPES.get(match_type, MATCH_REGEX)
+            self.regex = PATTERNS.get(self.match_type, match_type)
         else:
             self.regex = self.pattern
             self.match_type = 0  # Reset, in case of branching.

--- a/autoroutes.pyx
+++ b/autoroutes.pyx
@@ -20,6 +20,23 @@ MATCH_TYPES = {
     DEFAULT_MATCH_TYPE: MATCH_NOSLASH,
     'path': MATCH_ALL,
 }
+PATTERNS = {
+    MATCH_ALL: '.+',
+    MATCH_ALNUM: '\w+',
+    MATCH_ALPHA: '[a-zA-Z]+',
+    MATCH_DIGIT: '\d+',
+    MATCH_NOSLASH: '[^/]+',
+}
+
+
+cdef int common_root_len(string1, string2):
+    cdef unsigned int bound, i
+    bound = min(len(string1), len(string2))
+    for i in range(bound):
+        if path[i] != self.pattern[i]:
+            return i
+    else:
+        return bound
 
 
 @cython.final
@@ -30,6 +47,7 @@ cdef class Edge:
     cdef unsigned int pattern_len
     cdef str pattern_prefix
     cdef str pattern_suffix
+    cdef unsigned int pattern_prefix_len
     cdef unsigned int pattern_suffix_len
     cdef public Node child
     cdef public unsigned int match_type
@@ -47,16 +65,73 @@ cdef class Edge:
             str rest = self.pattern[prefix_len:]
         new_child.connect(self.child, rest)
         self.child = new_child
+        new_child.compile()
         self.pattern = self.pattern[:prefix_len]
+
+    cpdef Node join(self, str path):
+        cdef:
+            unsigned int common_len
+            unsigned int path_len = len(path)
+            Edge candidate = Edge(path, None)
+        candidate.compile()
+        if self.pattern_prefix_len and candidate.pattern_prefix_len:
+            common_len = common_root_len(self.pattern_prefix, candidate.pattern_prefix)
+            if not common_len:  # Nothing common.
+                return None
+            elif common_len < self.pattern_prefix_len:  # Remote prefix is consumed but not self.
+                self.branch_at(common_len)
+                return self.child.insert(path[common_len:])
+            elif common_len < candidate.pattern_prefix_len:  # Self prefix is consumed but not remote.
+                if self.match_type:
+                    self.branch_at(common_len)
+                return self.child.insert(path[common_len:])
+            # else prefix are equal and fully consumed.
+        elif self.pattern_prefix_len or candidate.pattern_prefix_len:
+            return None
+        # We now know prefix are either none or equal.
+        if not self.match_type and not candidate.match_type:
+            # No placeholder, thus no suffix, we're done.
+            if self.pattern_prefix_len:
+                return self.child
+            return None
+        elif not self.match_type:
+            return self.child.insert(path[self.pattern_prefix_len:])
+        elif not candidate.match_type or self.match_type == MATCH_REGEX or self.match_type != candidate.match_type:
+            # We cannot merge placeholders.
+            if self.pattern_prefix_len:
+                self.branch_at(self.pattern_start)
+                return self.child.insert(path[candidate.pattern_prefix_len:])
+            else:  # Nothing matched, abort.
+                return None
+        else:  # match types are mergeable, let's see if we should also deal with suffix.
+            if not self.pattern_suffix and not candidate.pattern_suffix:
+                return self.child
+            elif not self.pattern_suffix:
+                return self.child.insert(path[candidate.pattern_end:])
+            elif not candidate.pattern_suffix:
+                self.branch_at(self.pattern_end)
+                return self.child.insert(path[candidate.pattern_end:])
+            else:
+                common_len = common_root_len(self.pattern_suffix, candidate.pattern_suffix)
+                if not common_len:  # Nothing common in the suffix.
+                    return self.child.insert(path[candidate.pattern_end+1:])
+                elif common_len == self.pattern_suffix_len == candidate.pattern_suffix_len:
+                    return self.child
+                elif common_len < self.pattern_suffix_len:  # Remaining self suffix.
+                    self.branch_at(self.pattern_end+common_len+1)
+                    if candidate.pattern_end+common_len+1 < candidate.pattern_len:
+                        return self.child.insert(path[candidate.pattern_end+common_len+1:])
+                    return self.child
+                elif common_len < candidate.pattern_suffix_len:  # Remaining candidate suffix.
+                    return self.child.insert(path[candidate.pattern_end+common_len+1:])
+                # else:  # The whole self suffix is consumed and both are equal.
 
     cpdef str compile(self):
         self.pattern_start = self.pattern.find('{')  # Slow, but at compile it's ok.
         self.pattern_end = self.pattern.find('}')
         self.pattern_len = len(self.pattern)
-        if self.pattern_start > 0:
-            self.pattern_prefix = self.pattern[:self.pattern_start]
-        else:
-            self.pattern_prefix = None
+        self.pattern_prefix = self.pattern[:self.pattern_start] if self.pattern_start != -1 else self.pattern
+        self.pattern_prefix_len = len(self.pattern_prefix)
         if self.pattern_end != -1 and <unsigned>self.pattern_end < self.pattern_len:
             self.pattern_suffix = self.pattern[self.pattern_end+1:]
             self.pattern_suffix_len = len(self.pattern_suffix)
@@ -66,18 +141,26 @@ cdef class Edge:
         cdef:
             list parts
             str pattern, segment
+            unsigned int match_type
         if self.pattern_start != -1 and self.pattern_end != -1:
-            segment = self.pattern[self.pattern_start:self.pattern_end]
-            parts = segment.split(':')
-            if len(parts) == 2:
-                pattern = parts[1]
-            else:
-                pattern = DEFAULT_MATCH_TYPE
-            self.match_type = MATCH_TYPES.get(pattern, MATCH_REGEX)
+            pattern, self.match_type = Edge.extract_pattern(self.pattern[self.pattern_start:self.pattern_end])
         else:
             pattern = self.pattern
             self.match_type = 0  # Reset, in case of branching.
         return pattern
+
+    @staticmethod
+    cdef tuple extract_pattern(str segment):
+        cdef:
+            list parts
+            unsigned int match_type
+        parts = segment.split(':')
+        if len(parts) == 2:
+            pattern = parts[1]
+        else:
+            pattern = DEFAULT_MATCH_TYPE
+        match_type = MATCH_TYPES.get(pattern, MATCH_REGEX)
+        return pattern, match_type
 
     cdef unsigned int match(self, str path, unsigned int path_len, list params):
         cdef:
@@ -169,26 +252,15 @@ cdef class Node:
             self.edges.append(edge)
         return edge
 
-    cdef common_prefix(self, str path):
+    cdef Node common_edge(self, str path):
         cdef:
-            unsigned int i, bound
-            unsigned int path_len = len(path)
             Edge edge
+            Node node
         if self.edges:
             for edge in self.edges:
-                bound = min(path_len, len(edge.pattern))
-                i = 0
-                for i in range(bound):
-                    if path[i] != edge.pattern[i]:
-                        # Are we in the middle of a placeholder?
-                        if '{' in path[:i] and not '}' in path[:i]:
-                            i = path.find('{')
-                        break
-                else:
-                    i = bound
-                if i:
-                    return edge, path[:i]
-        return None, None
+                node = edge.join(path)
+                if node:
+                    return node
 
     cdef Edge match(self, str path, list params):
         cdef:
@@ -217,7 +289,6 @@ cdef class Node:
                         return edge.child.match(path[match_len:], params)
         return None
 
-
     cdef void compile(self):
         cdef:
             bool has_slug = False
@@ -239,10 +310,55 @@ cdef class Node:
                 self.pattern = pattern
                 self.regex = re.compile(pattern)
 
+    cdef Node insert(self, str path):
+        cdef:
+            Node node
+            # common edge
+            Edge edge = None
+            str prefix
+            int bound, end
+            unsigned int nb_slugs
+
+        print(f'Node.insert "{path}"')
+        # If there is no path to insert at the node, we just increase the mount
+        # point on the node and append the route.
+        if not len(path):
+            print('No path, aborting insert')
+            return self
+
+        node = self.common_edge(path)
+
+        if node:
+            print('Found a common edge', path, node)
+            return node
+
+        print('No node found, create a new one')
+
+        nb_slugs = path.count('{')
+        start = path.find('{')
+        if nb_slugs > 1:
+            # Break into parts
+            child = Node()
+            start = path.find('{', start + 1)  # Goto the next one.
+            self.connect(child, path[:start])
+            return child.insert(path[start:])
+        else:
+            child = Node()
+            edge = self.connect(child, path)
+            if nb_slugs:
+                edge.compile()
+                if edge.match_type == MATCH_REGEX:  # Non optimizable, split if pattern has prefix or suffix.
+                    if start > 0:  # slug does not start at first char (eg. foo{slug})
+                        edge.branch_at(start)
+                    end = path.find('}')
+                    if end+1 < len(path):  # slug does not end pattern (eg. {slug}foo)
+                        edge.branch_at(end+1)
+            return child
+
 
 cdef class Routes:
 
-    cdef Node root
+    cdef public Node root
 
     def __cinit__(self):
         self.root = Node()
@@ -251,7 +367,7 @@ cdef class Routes:
         cdef Node node
         if path.count('{') != path.count('}'):
             raise InvalidRoute('Unbalanced curly brackets for "{path}"'.format(path=path))
-        node = self.insert(self.root, path)
+        node = self.root.insert(path)
         node.attach_route(path, payload)
         self.compile(self.root)
 
@@ -273,25 +389,7 @@ cdef class Routes:
         return None, None
 
     def dump(self):
-        self._dump(self.root)
-
-    cdef _dump(self, node, level=0):
-        i = " " * level * 4
-        print(f'{i}(o)')
-        if node.pattern:
-            print(f'{i}| regexp: %s' % node.pattern)
-        if node.payload:
-            print(f'{i}| data: %s' % node.payload)
-        if node.path:
-            print(f'{i}| path: %s' % node.path)
-            print(f'{i}| slugs: %s' % node.slugs)
-        if node.edges:
-            for edge in node.edges:
-                print(f'{i}' + '\--- %s' % edge.pattern)
-                if edge.match_type:
-                    print(f'{i} |    match_type: %d' % edge.match_type)
-                if edge.child:
-                    self._dump(edge.child, level + 1)
+        dump(self.root)
 
     cdef compile(self, Node node):
         cdef:
@@ -301,47 +399,23 @@ cdef class Routes:
             for edge in node.edges:
                 self.compile(edge.child)
 
-    cdef Node insert(self, Node tree, str path):
-        cdef:
-            Node node = tree
-            # common edge
-            Edge edge = None
-            str prefix
-            int bound, end
-            unsigned int nb_slugs
 
-        # If there is no path to insert at the node, we just increase the mount
-        # point on the node and append the route.
-        if not len(path):
-            return tree
-
-        edge, prefix = node.common_prefix(path)
-
-        if not edge:
-            nb_slugs = path.count('{')
-            start = path.find('{')
-            if nb_slugs > 1:
-                # Break into parts
-                child = Node()
-                start = path.find('{', start + 1)  # Goto the next one.
-                node.connect(child, path[:start])
-                return self.insert(child, path[start:])
+cdef dump(node, level=0):
+    types = {v: k for k, v in MATCH_TYPES.items()}
+    i = " " * level * 4
+    print(f'{i}(o)')
+    if node.pattern:
+        print(f'{i}| regexp: %s' % node.pattern)
+    if node.payload:
+        print(f'{i}| data: %s' % node.payload)
+    if node.path:
+        print(f'{i}| path: %s' % node.path)
+        print(f'{i}| slugs: %s' % node.slugs)
+    if node.edges:
+        for edge in node.edges:
+            if edge.match_type:
+                print(f'{i}' + '\--- {%s}' % types.get(edge.match_type))
             else:
-                child = Node()
-                edge = node.connect(child, path)
-                if nb_slugs:
-                    edge.compile()
-                    if edge.match_type == MATCH_REGEX:  # Non optimizable, split if pattern has prefix or suffix.
-                        if start > 0:  # slug does not start at first char (eg. foo{slug})
-                            edge.branch_at(start)
-                        end = path.find('}')
-                        if end+1 < len(path):  # slug does not end pattern (eg. {slug}foo)
-                            edge.branch_at(end+1)
-                return child
-        elif len(prefix) == len(edge.pattern):
-            if len(path) > len(prefix):
-                return self.insert(edge.child, path[len(prefix):])
-            return edge.child
-        elif len(prefix) < len(edge.pattern):
-            edge.branch_at(len(prefix))
-            return self.insert(edge.child, path[len(prefix):])
+                print(f'{i}' + '\--- %s' % edge.pattern)
+            if edge.child:
+                dump(edge.child, level + 1)

--- a/autoroutes.pyx
+++ b/autoroutes.pyx
@@ -46,8 +46,8 @@ cdef class Edge:
     cdef int pattern_start
     cdef int pattern_end
     cdef unsigned int pattern_len
-    cdef str pattern_prefix
-    cdef str pattern_suffix
+    cdef public str pattern_prefix
+    cdef public str pattern_suffix
     cdef unsigned int pattern_prefix_len
     cdef unsigned int pattern_suffix_len
     cdef public Node child
@@ -359,7 +359,6 @@ cdef class Routes:
 
 
 cdef dump(node, level=0):
-    types = {v: k for k, v in MATCH_TYPES.items()}
     i = " " * level * 4
     print(f'{i}(o)')
     if node.pattern:
@@ -372,8 +371,9 @@ cdef dump(node, level=0):
     if node.edges:
         for edge in node.edges:
             if edge.match_type:
-                print(f'{i}' + '\--- {%s}' % types.get(edge.match_type))
+                pattern = edge.pattern_prefix + edge.regex + edge.pattern_suffix or ''
             else:
-                print(f'{i}' + '\--- %s' % edge.pattern)
+                pattern = edge.pattern
+            print(f'{i}' + '\--- %s' % pattern)
             if edge.child:
                 dump(edge.child, level + 1)

--- a/autoroutes.pyx
+++ b/autoroutes.pyx
@@ -183,7 +183,7 @@ cdef class Edge:
                     i = path_len
         if i:
             params.append(path[self.pattern_start:i])  # Slow.
-            if self.pattern_suffix_len and i < self.pattern_len:
+            if self.pattern_suffix_len:
                 # The placeholder is not at the end (eg. "{name}.json").
                 if path[i:i+self.pattern_suffix_len] != self.pattern_suffix:
                     return 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+from autoroutes import Routes
+
+
+@pytest.fixture
+def routes():
+    routes_ = Routes()
+    yield routes_
+    routes_.dump()  # Will display only in case of failure.
+    del routes_

--- a/tests/test_edge.py
+++ b/tests/test_edge.py
@@ -4,8 +4,9 @@ from autoroutes import Edge, Node
 
 
 @pytest.mark.parametrize('pattern,expected', [
-    ['{id}', 'string'],
-    ['{id:digit}', 'digit'],
+    ['{id}', '[^/]+'],
+    ['{id:string}', '[^/]+'],
+    ['{id:digit}', '\d+'],
     ['{id:\d+}', '\d+'],
     ['{id:[abc]}', '[abc]'],
     ['{id:.+}', '.+'],

--- a/tests/test_edge.py
+++ b/tests/test_edge.py
@@ -11,7 +11,9 @@ from autoroutes import Edge, Node
     ['{id:.+}', '.+'],
 ])
 def test_edge_compile(pattern, expected):
-    assert Edge(pattern, Node()).compile() == expected
+    edge = Edge(pattern, Node())
+    edge.compile()
+    assert edge.regex == expected
 
 
 def test_edge_insert_same_path(routes):

--- a/tests/test_edge.py
+++ b/tests/test_edge.py
@@ -259,3 +259,37 @@ def test_edge_join_same_suffix_root(routes):
     leaf = root.edges[0].child.edges[1].child
     assert leaf.payload == {'x': '2'}
     assert root.edges[0].child.edges[1].pattern == 'z'
+
+
+def test_edge_insert_same_placeholder_and_suffix(routes):
+    routes.add('{bar}/foo', x='1')
+    root = routes.root
+    assert len(root.edges) == 1
+    routes.add('{bar}/foo', y='2')
+    assert len(root.edges) == 1
+    assert root.edges[0].child.payload == {'x': '1', 'y': '2'}
+
+
+def test_edge_insert_same_placeholder_with_different_suffix(routes):
+    routes.add('{bar}/foo', x='1')
+    root = routes.root
+    assert len(root.edges) == 1
+    assert root.edges[0].child.payload == {'x': '1'}
+    routes.add('{bar}/bar', y='2')
+    assert len(root.edges) == 1
+    assert not root.edges[0].child.payload
+    assert len(root.edges[0].child.edges) == 2
+    assert root.edges[0].child.edges[0].child.payload == {'x': '1'}
+    assert root.edges[0].child.edges[1].child.payload == {'y': '2'}
+
+
+def test_edge_insert_same_placeholder_with_one_suffix(routes):
+    routes.add('{bar}', x='1')
+    root = routes.root
+    assert len(root.edges) == 1
+    assert root.edges[0].child.payload == {'x': '1'}
+    routes.add('{bar}/bar', y='2')
+    assert len(root.edges) == 1
+    assert root.edges[0].child.payload == {'x': '1'}
+    assert len(root.edges[0].child.edges) == 1
+    assert root.edges[0].child.edges[0].child.payload == {'y': '2'}

--- a/tests/test_edge.py
+++ b/tests/test_edge.py
@@ -12,3 +12,247 @@ from autoroutes import Edge, Node
 ])
 def test_edge_compile(pattern, expected):
     assert Edge(pattern, Node()).compile() == expected
+
+
+def test_edge_insert_same_path(routes):
+    routes.add('/foo', x='1')
+    root = routes.root
+    assert len(root.edges) == 1
+    routes.add('/foo', y='2')
+    assert len(root.edges) == 1
+    assert root.edges[0].child.payload == {'x': '1', 'y': '2'}
+
+
+def test_edge_insert_prefix_vs_placeholder(routes):
+    routes.add('foo', x='1')
+    root = routes.root
+    assert len(root.edges) == 1
+    routes.add('{foo}', x='2')
+    assert len(root.edges) == 2
+    assert root.edges[0].child.payload == {'x': '1'}
+    assert root.edges[1].child.payload == {'x': '2'}
+
+
+def test_edge_join_longer_path(routes):
+    routes.add('/foo', x='1')
+    root = routes.root
+    assert len(root.edges) == 1
+    assert not root.edges[0].child.edges
+    routes.add('/foo/bar', x='2')
+    leaf = root.edges[0].child
+    assert leaf.payload == {'x': '1'}
+    assert root.edges[0].pattern == '/foo'
+    leaf = root.edges[0].child.edges[0].child
+    assert leaf.payload == {'x': '2'}
+    assert root.edges[0].child.edges[0].pattern == '/bar'
+
+
+def test_edge_join_shorter_path(routes):
+    routes.add('/foo/bar', x='1')
+    root = routes.root
+    assert len(root.edges) == 1
+    assert root.edges[0].pattern == '/foo/bar'
+    routes.add('/foo', x='2')
+    assert len(root.edges) == 1
+    leaf = root.edges[0].child
+    assert leaf.payload == {'x': '2'}
+    assert root.edges[0].pattern == '/foo'
+    assert len(root.edges[0].child.edges) == 1
+    leaf = root.edges[0].child.edges[0].child
+    assert leaf.payload == {'x': '1'}
+    assert root.edges[0].child.edges[0].pattern == '/bar'
+
+
+def test_edge_join_same_root(routes):
+    routes.add('/foo/bar', x='1')
+    root = routes.root
+    assert len(root.edges) == 1
+    assert root.edges[0].pattern == '/foo/bar'
+    routes.add('/foo/baz', x='2')
+    assert len(root.edges) == 1
+    assert not root.edges[0].child.payload
+    assert root.edges[0].pattern == '/foo/ba'
+    assert len(root.edges[0].child.edges) == 2
+    leaf = root.edges[0].child.edges[0].child
+    assert leaf.payload == {'x': '1'}
+    assert root.edges[0].child.edges[0].pattern == 'r'
+    leaf = root.edges[0].child.edges[1].child
+    assert leaf.payload == {'x': '2'}
+    assert root.edges[0].child.edges[1].pattern == 'z'
+
+
+def test_edge_insert_same_path_and_placeholder(routes):
+    routes.add('/foo/{bar}', x='1')
+    root = routes.root
+    assert len(root.edges) == 1
+    routes.add('/foo/{bar}', y='2')
+    assert len(root.edges) == 1
+    assert root.edges[0].child.payload == {'x': '1', 'y': '2'}
+
+
+def test_edge_insert_same_path_and_placeholder_type(routes):
+    routes.add('/foo/{bar:digit}', x='1')
+    root = routes.root
+    assert len(root.edges) == 1
+    routes.add('/foo/{bar:digit}', y='2')
+    assert len(root.edges) == 1
+    assert root.edges[0].child.payload == {'x': '1', 'y': '2'}
+
+
+def test_edge_insert_same_path_and_placeholder_type_w_different_name(routes):
+    routes.add('/foo/{bar:digit}', x='1')
+    root = routes.root
+    assert len(root.edges) == 1
+    routes.add('/foo/{baz:digit}', y='2')
+    assert len(root.edges) == 1
+    assert root.edges[0].child.payload == {'x': '1', 'y': '2'}
+
+
+def test_edge_insert_same_prefix_and_different_placeholder(routes):
+    routes.add('/foo/{bar:digit}', x='1')
+    root = routes.root
+    assert len(root.edges) == 1
+    routes.add('/foo/{bar:string}', x='2')
+    assert len(root.edges) == 1
+    assert root.edges[0].pattern == '/foo/'
+    assert len(root.edges[0].child.edges) == 2
+    assert root.edges[0].child.edges[0].pattern == '{bar:digit}'
+    assert root.edges[0].child.edges[0].child.payload == {'x': '1'}
+    assert root.edges[0].child.edges[1].pattern == '{bar:string}'
+    assert root.edges[0].child.edges[1].child.payload == {'x': '2'}
+
+
+def test_edge_insert_same_prefix_and_different_placeholder_and_suffix(routes):
+    routes.add('/foo/{bar:digit}/baz', x='1')
+    root = routes.root
+    assert len(root.edges) == 1
+    routes.add('/foo/{bar:string}/baz', x='2')
+    assert len(root.edges) == 1
+    assert root.edges[0].pattern == '/foo/'
+    assert len(root.edges[0].child.edges) == 2
+    assert root.edges[0].child.edges[0].pattern == '{bar:digit}/baz'
+    assert root.edges[0].child.edges[0].child.payload == {'x': '1'}
+    assert root.edges[0].child.edges[1].pattern == '{bar:string}/baz'
+    assert root.edges[0].child.edges[1].child.payload == {'x': '2'}
+
+
+def test_edge_join_longer_prefix_with_local_placeholder(routes):
+    routes.add('/foo/{bar}', x='1')
+    root = routes.root
+    assert len(root.edges) == 1
+    assert not root.edges[0].child.edges
+    routes.add('/foo/baz', x='2')
+    assert root.edges[0].pattern == '/foo/'
+    assert not root.edges[0].child.payload
+    leaf = root.edges[0].child.edges[0].child
+    assert leaf.payload == {'x': '1'}
+    assert root.edges[0].child.edges[0].pattern == '{bar}'
+    leaf = root.edges[0].child.edges[1].child
+    assert leaf.payload == {'x': '2'}
+    assert root.edges[0].child.edges[1].pattern == 'baz'
+
+
+def test_edge_join_longer_prefix_with_local_placeholder2(routes):
+    routes.add('/foo/baz/{bar}', x='1')
+    root = routes.root
+    assert len(root.edges) == 1
+    assert not root.edges[0].child.edges
+    routes.add('/foo/bar', x='2')
+    assert root.edges[0].pattern == '/foo/ba'
+    assert not root.edges[0].child.payload
+    leaf = root.edges[0].child.edges[0].child
+    assert leaf.payload == {'x': '1'}
+    assert root.edges[0].child.edges[0].pattern == 'z/{bar}'
+    leaf = root.edges[0].child.edges[1].child
+    assert leaf.payload == {'x': '2'}
+    assert root.edges[0].child.edges[1].pattern == 'r'
+
+
+def test_edge_join_longer_prefix_with_remote_placeholder(routes):
+    routes.add('/foo/baz', x='1')
+    root = routes.root
+    assert len(root.edges) == 1
+    assert not root.edges[0].child.edges
+    routes.add('/foo/{bar}', x='2')
+    assert root.edges[0].pattern == '/foo/'
+    assert not root.edges[0].child.payload
+    leaf = root.edges[0].child.edges[0].child
+    assert leaf.payload == {'x': '1'}
+    assert root.edges[0].child.edges[0].pattern == 'baz'
+    leaf = root.edges[0].child.edges[1].child
+    assert leaf.payload == {'x': '2'}
+    assert root.edges[0].child.edges[1].pattern == '{bar}'
+
+
+def test_edge_join_longer_prefix_with_remote_placeholder2(routes):
+    routes.add('/foo/bar', x='1')
+    root = routes.root
+    assert len(root.edges) == 1
+    assert not root.edges[0].child.edges
+    routes.add('/foo/baz/{bar}', x='2')
+    assert root.edges[0].pattern == '/foo/ba'
+    assert not root.edges[0].child.payload
+    leaf = root.edges[0].child.edges[0].child
+    assert leaf.payload == {'x': '1'}
+    assert root.edges[0].child.edges[0].pattern == 'r'
+    leaf = root.edges[0].child.edges[1].child
+    assert leaf.payload == {'x': '2'}
+    assert root.edges[0].child.edges[1].pattern == 'z/{bar}'
+
+
+def test_edge_insert_same_path_placeholder_and_suffix(routes):
+    routes.add('/foo/{bar}/baz', x='1')
+    root = routes.root
+    assert len(root.edges) == 1
+    routes.add('/foo/{bar}/baz', y='2')
+    assert len(root.edges) == 1
+    assert root.edges[0].child.payload == {'x': '1', 'y': '2'}
+
+
+def test_edge_join_longer_suffix(routes):
+    routes.add('/foo/{bar}/', x='1')
+    root = routes.root
+    assert len(root.edges) == 1
+    assert not root.edges[0].child.edges
+    routes.add('/foo/{bar}/baz', x='2')
+    leaf = root.edges[0].child
+    assert leaf.payload == {'x': '1'}
+    assert root.edges[0].pattern == '/foo/{bar}/'
+    leaf = root.edges[0].child.edges[0].child
+    assert leaf.payload == {'x': '2'}
+    assert root.edges[0].child.edges[0].pattern == 'baz'
+
+
+def test_edge_join_shorter_suffix(routes):
+    routes.add('/foo/{bar}/baz', x='1')
+    root = routes.root
+    assert len(root.edges) == 1
+    assert root.edges[0].pattern == '/foo/{bar}/baz'
+    routes.add('/foo/{bar}/', x='2')
+    assert root.edges[0].pattern == '/foo/{bar}/'
+    assert len(root.edges) == 1
+    leaf = root.edges[0].child
+    assert leaf.payload == {'x': '2'}
+    assert root.edges[0].pattern == '/foo/{bar}/'
+    assert len(root.edges[0].child.edges) == 1
+    leaf = root.edges[0].child.edges[0].child
+    assert leaf.payload == {'x': '1'}
+    assert root.edges[0].child.edges[0].pattern == 'baz'
+
+
+def test_edge_join_same_suffix_root(routes):
+    routes.add('/foo/{bar}/bar', x='1')
+    root = routes.root
+    assert len(root.edges) == 1
+    assert root.edges[0].pattern == '/foo/{bar}/bar'
+    routes.add('/foo/{bar}/baz', x='2')
+    assert len(root.edges) == 1
+    assert not root.edges[0].child.payload
+    assert root.edges[0].pattern == '/foo/{bar}/ba'
+    assert len(root.edges[0].child.edges) == 2
+    leaf = root.edges[0].child.edges[0].child
+    assert leaf.payload == {'x': '1'}
+    assert root.edges[0].child.edges[0].pattern == 'r'
+    leaf = root.edges[0].child.edges[1].child
+    assert leaf.payload == {'x': '2'}
+    assert root.edges[0].child.edges[1].pattern == 'z'

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -65,6 +65,20 @@ def test_add_param_regex_can_be_complex(routes):
     assert routes.match('/foo/nowhere')[1] is None
 
 
+def test_add_with_clashing_regexes(routes):
+    routes.add('/foo/{path:[abc]}', something='x')
+    routes.add('/foo/{path:[xyz]}', something='y')
+    assert routes.match('/foo/a') == ({'something': 'x'}, {'path': 'a'})
+    assert routes.match('/foo/x') == ({'something': 'y'}, {'path': 'x'})
+
+
+def test_add_with_regex_clashing_with_placeholder(routes):
+    routes.add('/foo/{path:[abc]}', something='x')
+    routes.add('/foo/{path:digit}', something='y')
+    assert routes.match('/foo/a') == ({'something': 'x'}, {'path': 'a'})
+    assert routes.match('/foo/12') == ({'something': 'y'}, {'path': '12'})
+
+
 def test_add_can_use_shortcut_types(routes):
     routes.add('/foo/{id:digit}/path', something='x')
     assert routes.match('/foo/123/path')[1] == {'id': '123'}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -204,3 +204,9 @@ def test_add_deals_with_multiple_clashing_vars(routes):
         {'foo': 'pbf'}, {'names': 'mylayer', 'x': '0', 'y': '0', 'z': '0'})
     assert routes.match('/mylayer/0/0/0.mvt') == (
         {'foo': 'mvt'}, {'names': 'mylayer', 'x': '0', 'y': '0', 'z': '0'})
+
+
+def test_match_long_placeholder_with_suffix(routes):
+    routes.add('/{bar}/', something='x')
+    assert routes.match('/sdlfkseirsldkfjsie/') == (
+        {'something': 'x'}, {'bar': 'sdlfkseirsldkfjsie'})

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -17,63 +17,63 @@ def test_simple_follow(routes):
     assert routes.match('/foo') == ({'something': 'x'}, {})
 
 
-def test_follow_root(routes):
+def test_add_root(routes):
     routes.add('/', something='x')
     assert routes.match('/') == ({'something': 'x'}, {})
 
 
-def test_follow_unicode_routes(routes):
+def test_add_unicode_routes(routes):
     routes.add('/éèà', something='àô')
     assert routes.match('/éèà') == ({'something': 'àô'}, {})
 
 
-def test_follow_unknown_path(routes):
+def test_add_unknown_path(routes):
     routes.add('/foo/', data='x')
     assert routes.match('/bar/') == (None, None)
 
 
-def test_follow_unknown_path_with_param(routes):
+def test_add_unknown_path_with_param(routes):
     routes.add('/foo/{id}', data='x')
     assert routes.match('/bar/foo') == (None, None)
 
 
-def test_follow_return_params(routes):
+def test_add_return_params(routes):
     routes.add('/foo/{id}', data='x')
     assert routes.match('/foo/bar')[1] == {'id': 'bar'}
 
 
-def test_follow_return_params_in_the_middle(routes):
+def test_add_return_params_in_the_middle(routes):
     routes.add('/foo/{id}/bar', data='x')
     assert routes.match('/foo/22/bar') == ({'data': 'x'}, {'id': '22'})
 
 
-def test_follow_can_handle_different_subpaths_after_placeholder(routes):
+def test_add_can_handle_different_subpaths_after_placeholder(routes):
     routes.add('/foo/{id}/bar', data='x')
     routes.add('/foo/{id}/baz', data='y')
     assert routes.match('/foo/22/bar') == ({'data': 'x'}, {'id': '22'})
     assert routes.match('/foo/33/baz') == ({'data': 'y'}, {'id': '33'})
 
 
-def test_follow_param_regex_can_be_changed(routes):
+def test_add_param_regex_can_be_changed(routes):
     routes.add('/foo/{id:\d+}', something='x')
     assert routes.match('/foo/bar') == (None, None)
     assert routes.match('/foo/22') == ({'something': 'x'}, {'id': '22'})
 
 
-def test_follow_param_regex_can_consume_slash(routes):
+def test_add_param_regex_can_consume_slash(routes):
     routes.add('/foo/{path:.+}', something='x')
     assert routes.match('/foo/path/to/somewhere') == \
         ({'something': 'x'}, {'path': 'path/to/somewhere'})
 
 
-def test_follow_param_regex_can_be_complex(routes):
+def test_add_param_regex_can_be_complex(routes):
     routes.add('/foo/{path:(some|any)where}', something='x')
     assert routes.match('/foo/somewhere')[1] == {'path': 'somewhere'}
     assert routes.match('/foo/anywhere')[1] == {'path': 'anywhere'}
     assert routes.match('/foo/nowhere')[1] is None
 
 
-def test_follow_can_use_shortcut_types(routes):
+def test_add_can_use_shortcut_types(routes):
     routes.add('/foo/{id:digit}/path', something='x')
     assert routes.match('/foo/123/path')[1] == {'id': '123'}
     assert routes.match('/foo/abc/path')[1] is None
@@ -98,13 +98,13 @@ def test_variable_type_is_alpha(routes):
     assert routes.match('/foo/a2')[1] is None
 
 
-def test_follow_segment_can_mix_string_and_param(routes):
+def test_add_segment_can_mix_string_and_param(routes):
     routes.add('/foo.{ext}', data='x')
     assert routes.match('/foo.json')[1] == {'ext': 'json'}
     assert routes.match('/foo.txt')[1] == {'ext': 'txt'}
 
 
-def test_follow_with_clashing_placeholders_of_different_types(routes):
+def test_add_with_clashing_placeholders_of_different_types(routes):
     routes.add('horse/{id:digit}/subpath', data='x')
     routes.add('horse/{id}/other', data='y')
     assert routes.match('horse/22/subpath') == ({'data': 'x'}, {'id': '22'})
@@ -121,7 +121,7 @@ def test_connect_can_be_updated(routes):
     assert routes.match('/foo/') == ({'data': 'new', 'other': 'new'}, {})
 
 
-def test_follow_accept_func_as_data(routes):
+def test_add_accept_func_as_data(routes):
 
     def handler():
         pass
@@ -130,25 +130,25 @@ def test_follow_accept_func_as_data(routes):
     assert routes.match('/foo') == ({'handler': handler}, {})
 
 
-def test_follow_accepts_multiple_params(routes):
+def test_add_accepts_multiple_params(routes):
     routes.add('/foo/{id}/bar/{sub}', something='x')
     assert routes.match('/foo/id/bar/su') == \
         ({'something': 'x'}, {'id': 'id', 'sub': 'su'})
 
 
-def test_follow_accepts_multiple_params_in_succession(routes):
+def test_add_accepts_multiple_params_in_succession(routes):
     routes.add('/foo/{id}/{sub}', something='x')
     assert routes.match('/foo/id/su') == \
         ({'something': 'x'}, {'id': 'id', 'sub': 'su'})
 
 
-def test_follow_can_deal_with_clashing_edges(routes):
+def test_add_can_deal_with_clashing_edges(routes):
     routes.add('/foo/{id}/path', something='x')
     routes.add('/foo/{id}/{sub}', something='y')
     assert routes.match('/foo/id/path') == ({'something': 'x'}, {'id': 'id'})
 
 
-def test_follow_respesct_clashing_edges_registration_order(routes):
+def test_add_respesct_clashing_edges_registration_order(routes):
     routes.add('/foo/{id}/{sub}', something='y')
     routes.add('/foo/{id}/path', something='x')
     assert routes.match('/foo/id/path') == \


### PR DESCRIPTION
Consider those two paths:


    /foo/{name}/baz
    /foo/{id}/bar

Before this commit, given the two placeholders have different name,
that would have create two edges:

```
/foo/
    {name}/baz
    {id}/bar
```

So only one of those two URLs can ever match.
Now we have merged the two placeholders (which have same match_type):

```
/foo/
    {:some-string:}/
                    bar
                    baz
```